### PR TITLE
Improve election when quorum is flaky

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
         go-version: 1.15
 
     - name: Install Ginkgo
-      run: go get github.com/onsi/ginkgo/ginkgo
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.15.0
 
     - name: Build Binaries
       run: make binaries

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.15
 
       - name: Install Ginkgo
-        run: go get github.com/onsi/ginkgo/ginkgo
+        run: go get github.com/onsi/ginkgo/ginkgo@v1.15.0
 
       - name: Get version
         run: echo VERSION=$(git describe --tags) >> $GITHUB_ENV

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -34,6 +34,7 @@ var (
 	errNodeWatchClosed = errors.New("watch channel on znode was closed")
 
 	defaultMaxRandomWaitDuration = 2 * time.Second
+	defaultHeartbeatInterval     = 60 * time.Second
 )
 
 type ZooKeeperElection struct {
@@ -43,6 +44,7 @@ type ZooKeeperElection struct {
 	proposalNodePath      string
 	sessionTimeout        time.Duration
 	maxRandomWaitDuration time.Duration
+	heartbeatInterval     time.Duration
 	zk                    zkClient
 }
 
@@ -64,6 +66,7 @@ func newElectionWithZkClient(zk zkClient, electionPath string, candidateID strin
 		candidateID:           candidateID,
 		sessionTimeout:        sessionTimeout,
 		maxRandomWaitDuration: defaultMaxRandomWaitDuration,
+		heartbeatInterval:     defaultHeartbeatInterval,
 		log:                   l,
 	}
 }
@@ -177,6 +180,9 @@ func (e *ZooKeeperElection) waitForNodeDeletion(ctx context.Context, node string
 			}
 
 			e.log.Debugf("ignoring event type %s on node %s", ev.Type, node)
+
+		case <-time.After(e.heartbeatInterval):
+			return nil
 		}
 	}
 }

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -104,6 +104,12 @@ func (e *ZooKeeperElection) createProposalNode() error {
 func (e *ZooKeeperElection) deleteProposalNode() error {
 	err := e.zk.Delete(e.proposalNodePath)
 	if err != nil {
+		if errors.Is(err, zk.ErrNoNode) {
+			e.log.Debugf("own proposal node %s already gone while trying to delete", e.proposalNodePath)
+
+			return nil
+		}
+
 		return fmt.Errorf("delete own proposal node: %s: %w", e.proposalNodePath, err)
 	}
 

--- a/pkg/election/election_test.go
+++ b/pkg/election/election_test.go
@@ -552,6 +552,9 @@ type mockZkClient struct {
 	returnErrorForWatch  error
 	watchingCheckpointCh chan struct{}
 
+	returnChForWatchChildren    chan zk.Event
+	returnErrorForWatchChildren error
+
 	calledHasSessionNTimes int
 	returnForHasSession    []bool
 }
@@ -597,6 +600,10 @@ func (z *mockZkClient) Watch(path string) (<-chan zk.Event, error) {
 	}
 
 	return z.returnChForWatch, z.returnErrorForWatch
+}
+
+func (z *mockZkClient) WatchChildren(path string) (<-chan zk.Event, error) {
+	return z.returnChForWatchChildren, z.returnErrorForWatchChildren
 }
 
 func (z *mockZkClient) HasSession() bool {

--- a/pkg/election/zk.go
+++ b/pkg/election/zk.go
@@ -55,8 +55,11 @@ func (z *defaultZkClient) CreateNodeSequenceEphemeral(path string, data []byte) 
 
 func (z *defaultZkClient) CreateNode(path string) error {
 	_, err := z.conn.Create(path, nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
 
-	return fmt.Errorf("create: %w", err)
+	return nil
 }
 
 func (z *defaultZkClient) Delete(path string) error {

--- a/pkg/election/zk.go
+++ b/pkg/election/zk.go
@@ -28,6 +28,7 @@ type zkClient interface {
 	Delete(path string) error
 	ListChildren(path string) ([]string, error)
 	Watch(path string) (<-chan zk.Event, error)
+	WatchChildren(path string) (<-chan zk.Event, error)
 	HasSession() bool
 }
 
@@ -79,6 +80,15 @@ func (z *defaultZkClient) Watch(path string) (<-chan zk.Event, error) {
 	_, _, ch, err := z.conn.GetW(path)
 	if err != nil {
 		return nil, fmt.Errorf("watch: %w", err)
+	}
+
+	return ch, nil
+}
+
+func (z *defaultZkClient) WatchChildren(path string) (<-chan zk.Event, error) {
+	_, _, ch, err := z.conn.ChildrenW(path)
+	if err != nil {
+		return nil, fmt.Errorf("childrenwatch: %w", err)
 	}
 
 	return ch, nil


### PR DESCRIPTION
- Show election queue every 30s and when proposals change, which makes it more intuitive to know what state the election process is in by just looking at logs on any node
- Handle own proposal znode vanishing when resigning and when re-electing

Proposal znode can disappear when the whole zookeeper ensemble is down for longer than the session timeout.