### PR TITLE
Bugfix/ballot 3

### DIFF
--- a/cmd/ballot/ballot.go
+++ b/cmd/ballot/ballot.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/scality/ballot/pkg/cmd/info"
@@ -29,7 +30,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-var flagDebug = "debug"
+const (
+	flagDebug            = "debug"
+	timestampFormat      = time.RFC3339Nano
+	humanTimestampFormat = time.StampNano
+)
 
 var rootCmd = &cobra.Command{
 	Use: os.Args[0],
@@ -75,31 +80,38 @@ func initConfig() {
 
 	log.SetLevel(lvl)
 
+	var formatter log.Formatter
+
 	f := viper.GetString("log-format")
 	switch f {
 	case "json":
-		log.SetFormatter(&log.JSONFormatter{})
+		formatter = &log.JSONFormatter{
+			TimestampFormat: timestampFormat,
+		}
 
 	case "human":
-		log.SetFormatter(&log.TextFormatter{
+		formatter = &log.TextFormatter{
 			QuoteEmptyFields: true,
 			DisableSorting:   true,
-		})
+			FullTimestamp:    true,
+			TimestampFormat:  humanTimestampFormat,
+		}
 
 	case "raw":
-		log.SetFormatter(&log.TextFormatter{
+		formatter = &log.TextFormatter{
 			DisableColors:    true,
 			ForceQuote:       true,
 			FullTimestamp:    true,
+			TimestampFormat:  timestampFormat,
 			QuoteEmptyFields: true,
-		})
+		}
 
 	default:
 		log.Fatalf("invalid log format: %s", f)
 	}
 
+	log.SetFormatter(formatter)
 	log.SetReportCaller(viper.GetBool(flagDebug))
-
 	log.SetOutput(os.Stdout)
 }
 

--- a/hack/run-race.sh
+++ b/hack/run-race.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+kill_ballots() {
+    echo 'killing workers...' >&2
+    killall ballot-runrace
+}
+
+trap kill_ballots SIGINT
+
+go build -o ./ballot-runrace cmd/ballot/ballot.go
+
+SESSION_TIMEOUT=10s
+CMD="lockrun --lockfile=candidate -- sleep .1"
+
+./ballot-runrace run once --candidate-id candidate-1 --log-format human --zookeeper-session-timeout $SESSION_TIMEOUT -- $CMD &
+./ballot-runrace run once --candidate-id candidate-2 --log-format human --zookeeper-session-timeout $SESSION_TIMEOUT -- $CMD &
+./ballot-runrace run once --candidate-id candidate-3 --log-format human --zookeeper-session-timeout $SESSION_TIMEOUT -- $CMD &
+./ballot-runrace run once --candidate-id candidate-4 --log-format human --zookeeper-session-timeout $SESSION_TIMEOUT -- $CMD &
+./ballot-runrace run once --candidate-id candidate-5 --log-format human --zookeeper-session-timeout $SESSION_TIMEOUT -- $CMD &
+
+wait

--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -334,6 +334,8 @@ func (e *ZooKeeperElection) BecomeLeader(ctx context.Context) error {
 		return fmt.Errorf("leader election: %w", err)
 	}
 
+	var expectVersion int32
+
 	for {
 		prev, err := e.getPreviousProposal()
 		if err != nil {
@@ -343,7 +345,10 @@ func (e *ZooKeeperElection) BecomeLeader(ctx context.Context) error {
 		hasLowestProposal := prev == ""
 
 		if hasLowestProposal {
-			if e.hasActiveLeader() {
+			e.log.Debug("got the lowest proposal")
+
+			hasActiveLeader, lastSeenVersion := e.hasActiveLeader()
+			if hasActiveLeader {
 				// It is possible to have the lowest proposal and not be the
 				// actual leader, if all the previous ephemeral nodes have been
 				// auto-expired and there's still a leader running the process.
@@ -357,7 +362,7 @@ func (e *ZooKeeperElection) BecomeLeader(ctx context.Context) error {
 				continue
 			}
 
-			e.log.Info("am leader, continuing")
+			expectVersion = lastSeenVersion
 
 			break
 		} else {
@@ -372,7 +377,17 @@ func (e *ZooKeeperElection) BecomeLeader(ctx context.Context) error {
 		}
 	}
 
-	e.claimLeaderRole(ctx)
+	e.log.WithField("expectNodeVersion", expectVersion).Info("am leader, trying to claim")
+
+	expectVersion2, err := e.publishLeaderRole(expectVersion)
+	if err != nil {
+		return fmt.Errorf("unable to claim leadership (expected version %d, found %d): %w",
+			expectVersion, expectVersion2, err)
+	}
+
+	e.log.Info("am leader, claim ok, continuing")
+
+	e.publishLeaderRoleBackgroundTask(ctx, expectVersion2)
 
 	return nil
 }
@@ -381,7 +396,7 @@ func convertMsEpochToTime(ms int64) time.Time {
 	return time.Unix(ms/1000, (ms%1000)*1_000_000)
 }
 
-func (e *ZooKeeperElection) hasActiveLeader() bool {
+func (e *ZooKeeperElection) hasActiveLeader() (bool, int32) {
 	e.log.Info("checking if there is an active leader")
 
 	data, stat, err := e.zk.Get(e.basePath)
@@ -391,28 +406,29 @@ func (e *ZooKeeperElection) hasActiveLeader() bool {
 		// if we can't reach zk, assume there's already a
 		// leader, as we don't want to risk a split brain
 		// election
-		return true
+		return true, 0
 	}
 
+	version := stat.Version
 	mtime := convertMsEpochToTime(stat.Mtime)
 	since := time.Since(mtime)
 	hasActiveLeader := since < e.sessionTimeout && len(data) > 0
 
-	e.log.Debugf("active leader info: hasActiveLeader=%v descr=%s since=%s threshold=%s",
-		hasActiveLeader, string(data), since.String(), e.sessionTimeout.String())
+	e.log.Debugf("active leader info: hasActiveLeader=%v descr=%s since=%s threshold=%s nodeversion=%d",
+		hasActiveLeader, string(data), since.String(), e.sessionTimeout.String(), version)
 
 	if hasActiveLeader {
 		e.log.Infof("active leader '%s' was seen %s ago", string(data), since.String())
 	}
 
-	return hasActiveLeader
+	return hasActiveLeader, version
 }
 
-func (e *ZooKeeperElection) clearLeaderRole() {
+func (e *ZooKeeperElection) clearLeaderRole(expectVersion int32) {
 	e.lock("clearLeaderRole")
 	defer e.unlock("clearLeaderRole")
 
-	err := e.zk.Set(e.basePath, []byte{}, -1)
+	_, err := e.zk.Set(e.basePath, []byte{}, expectVersion)
 	if err != nil && !errors.Is(err, zk.ErrConnectionClosed) {
 		// don't log connections closed errors, as
 		// connections closed mean that the proposal node will
@@ -422,36 +438,39 @@ func (e *ZooKeeperElection) clearLeaderRole() {
 	}
 }
 
-func (e *ZooKeeperElection) publishLeaderRole() {
+func (e *ZooKeeperElection) publishLeaderRole(expectVersion int32) (int32, error) {
 	e.lock("publishLeaderRole")
 	defer e.unlock("publishLeaderRole")
 
 	if e.proposalNodePath == "" {
 		e.log.Debug("in the process of resigning, not publishing")
 
-		return
+		return 0, nil
 	}
 
 	e.log.Debug("publishing leader state")
 
-	err := e.zk.Set(e.basePath, e.serializeLeaderInfoUnlocked(), -1)
+	foundVersion, err := e.zk.Set(e.basePath, e.serializeLeaderInfoUnlocked(), expectVersion)
 	if err != nil {
-		e.log.Errorf("could not publish leader role: %v", err)
-
-		return
+		return foundVersion, fmt.Errorf("publish leader role: %w", err)
 	}
+
+	e.log.Debugf("published leader state expectv=%d newv=%d", expectVersion, foundVersion)
+
+	return foundVersion, nil
 }
 
-func (e *ZooKeeperElection) claimLeaderRole(ctx context.Context) {
+func (e *ZooKeeperElection) publishLeaderRoleBackgroundTask(ctx context.Context, expectVersion int32) {
 	e.lock("claimLeaderRole")
 	defer e.unlock("claimLeaderRole")
 
 	e.leaderResignChan = make(chan struct{})
+	localExpectVersion := expectVersion
 
 	go func() {
 		t := time.NewTicker(e.sessionTimeout / 2)
 		defer t.Stop()
-		defer e.clearLeaderRole()
+		defer e.clearLeaderRole(localExpectVersion)
 
 		for {
 			select {
@@ -462,7 +481,12 @@ func (e *ZooKeeperElection) claimLeaderRole(ctx context.Context) {
 				return
 
 			case <-t.C:
-				e.publishLeaderRole()
+				foundVersion, err := e.publishLeaderRole(localExpectVersion)
+				if err != nil {
+					e.log.Errorf("leader claim loop: %v", err)
+				}
+
+				localExpectVersion = foundVersion
 			}
 		}
 	}()

--- a/pkg/election/types.go
+++ b/pkg/election/types.go
@@ -19,4 +19,5 @@ import "context"
 type Election interface {
 	BecomeLeader(ctx context.Context) error
 	Resign(ctx context.Context) error
+	Reinit() error
 }

--- a/pkg/election/zk.go
+++ b/pkg/election/zk.go
@@ -33,6 +33,8 @@ type zkClient interface {
 	Events() <-chan zk.Event
 	Get(path string) ([]byte, *zk.Stat, error)
 	Set(path string, data []byte, v int32) error
+
+	Disconnect()
 }
 
 type defaultZkClient struct {
@@ -114,4 +116,8 @@ func (z *defaultZkClient) Get(path string) ([]byte, *zk.Stat, error) {
 func (z *defaultZkClient) Set(path string, data []byte, v int32) error {
 	_, err := z.conn.Set(path, data, v)
 	return err
+}
+
+func (z *defaultZkClient) Disconnect() {
+	z.conn.Close()
 }


### PR DESCRIPTION
- Ensure that election is still running by using node version numbers for mvcc updates, a few ms window was open during which the existing-leader-but-its-ephemeral-node-gone heuristic would let 2 leaders coexist.
- Close and reopen connection to zookeeper after each election failure, to ensure that ephemeral nodes are not kept around because of reused session id (would prevent ballot processes from noticing when a new election is required).
- Improve logs for better debugging (with finer timestamps and hostname).