### PR TITLE
Implement info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,91 @@ invocation queueing, allowing concurrent invocations.
 
 ### Info
 
-Not implemented yet.
+The info command shows the current state of the election:
+
+- The current leader
+- The list of candidates
+- Data about each entry (proposal, last seen time, host, pid, candidate id, etc)
+- Notes about each entry that could have an effect on the current election.
+  These notes often include conditional phrasing, because they are observations
+  based on heuristics, as it is often not possible to know what really is
+  happening until later.
 
 #### Options
 
-| Parameter | Description | Default | Allowed values |
-| --- | --- | --- | --- |
+See Global Configuration for common options.
 
 #### Examples
+
+Here is an example of an election where the leader just resigned (for example
+because its child process completed successfully, and the configured policy is
+`reelect`). We can see that `candidate-2` is well positioned to be the leader,
+but is prevented by `candidate-5` which still holds a lease (`last heartbeat
+2.242563s ago`). When `candidate-5`'s heartbeat misses (2.75s from now, or
+`sessionTimeout/2` after its last heartbeat), `candidate-2` will proceed with
+leadership.
+
+```yaml
+$ ballot --zookeeper-servers localhost:2181 --zookeeper-base-path /ballot/myservice info
+leader:
+  id: candidate-5
+  host: host-5
+  pid: "25048"
+  proposalTime: 2022-01-07 13:40:17.537208 -0800 PST m=+1.119309658
+  proposalNode: /ballot/myservice/proposal-0000031785
+  sessionTimeout: 10s
+  notes:
+  - is leader
+  - last heartbeat 2.242563s ago
+  - possibly resigning
+  - election may be in progress
+  lastSeenTime: 2022-01-07 13:40:47.55661 -0800 PST m=+31.138087501
+allCandidates:
+- id: candidate-2
+  host: host-2
+  pid: "5967"
+  proposalTime: 2022-01-07 13:40:17.540773 -0800 PST m=+1.111020024
+  proposalNode: /ballot/myservice/proposal-0000031786
+  sessionTimeout: 10s
+  notes:
+  - should be leader but another candidate is claiming the role
+  - possibly waiting for previous leader resignation
+  - proposal node created 32.259036s ago
+- id: candidate-3
+  host: host-3
+  pid: "6516"
+  proposalTime: 2022-01-07 13:40:17.540755 -0800 PST m=+1.112006091
+  proposalNode: /ballot/myservice/proposal-0000031787
+  sessionTimeout: 10s
+  notes:
+  - proposal node created 32.259585s ago
+- id: candidate-1
+  host: host-1
+  pid: "152"
+  proposalTime: 2022-01-07 13:40:17.540778 -0800 PST m=+1.113612800
+  proposalNode: /ballot/myservice/proposal-0000031788
+  sessionTimeout: 10s
+  notes:
+  - proposal node created 32.260036s ago
+- id: candidate-4
+  host: host-4
+  pid: "8053"
+  proposalTime: 2022-01-07 13:40:17.540928 -0800 PST m=+1.123033944
+  proposalNode: /ballot/myservice/proposal-0000031789
+  sessionTimeout: 10s
+  notes:
+  - proposal node created 32.260125s ago
+- id: candidate-5
+  host: host-5
+  pid: "4389"
+  proposalTime: 2022-01-07 13:40:47.827953 -0800 PST m=+31.409424660
+  proposalNode: /ballot/myservice/proposal-0000031790
+  sessionTimeout: 10s
+  notes:
+  - this candidate id claimed leadership
+  - proposal node created 1.973348s ago
+
+```
 
 ### Watch
 

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -149,8 +148,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
-github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -291,18 +288,14 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -329,7 +322,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -375,7 +367,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/cmd/info/info.go
+++ b/pkg/cmd/info/info.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Scality, Inc
+// Copyright 2021-2022 Scality, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,18 +15,65 @@
 package info
 
 import (
-	"github.com/sirupsen/logrus"
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/scality/ballot/pkg/conf"
+	"github.com/scality/ballot/pkg/election"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
+
+func runInfo(ctx context.Context, cmd *cobra.Command, args []string, appLogger *log.Entry) {
+	electionClient, err := election.NewZooKeeperElectionClient(
+		conf.GetZooKeeperServers(),
+		conf.GetZooKeeperBasePath(),
+		conf.GetZooKeeperSessionTimeout(),
+		conf.GetDebugMode(),
+		appLogger.WithField("name", "election-client"),
+	)
+	if err != nil {
+		appLogger.Fatal(err)
+
+		return
+	}
+
+	status, err := electionClient.Inspect()
+	if err != nil {
+		appLogger.Fatal(err)
+	}
+
+	format := conf.GetOutputFormat()
+	switch format {
+	case "yaml":
+		enc := yaml.NewEncoder(os.Stdout)
+		_ = enc.Encode(status)
+
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
+		_ = enc.Encode(status)
+
+	default:
+		appLogger.Fatalf("invalid output format '%s'", format)
+	}
+}
 
 var infoCmd = cobra.Command{
 	Use:   "info",
 	Short: "List candidates under a ZooKeeper path",
 	Run: func(cmd *cobra.Command, args []string) {
-		logrus.Fatal("not implemented")
+		ctx := context.Background()
+		rootLog := log.StandardLogger().WithContext(ctx).WithField("name", "cmd-info")
+
+		runInfo(ctx, cmd, args, rootLog)
 	},
 }
 
 func Add(parent *cobra.Command) {
+	conf.AddInfoFlags(&infoCmd)
+
 	parent.AddCommand(&infoCmd)
 }

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Scality, Inc
+// Copyright 2021-2022 Scality, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ const (
 	flagZooKeeperBasePath       = "zookeeper-base-path"
 	flagZooKeeperSessionTimeout = "zookeeper-session-timeout"
 	flagDebugMode               = "debug"
+	flagOutputFormat            = "output-format"
 )
 
 var defaultZooKeeperSessionTimeout = 5 * time.Second
@@ -55,6 +56,14 @@ func GetZooKeeperBasePath() string {
 
 func GetZooKeeperSessionTimeout() time.Duration {
 	return viper.GetDuration(flagZooKeeperSessionTimeout)
+}
+
+func GetDebugMode() bool {
+	return viper.GetBool(flagDebugMode)
+}
+
+func GetOutputFormat() string {
+	return viper.GetString(flagOutputFormat)
 }
 
 var errInvalidOnElectionFailureFlag = errors.New("invalid value for " + flagOnElectionFailure)
@@ -143,7 +152,7 @@ func ParseRunParams(v *viper.Viper) (*RunParams, error) {
 		CandidateID:       v.GetString(flagCandidateID),
 		Schedule:          v.GetString(flagSchedule),
 		MultipleRuns:      v.IsSet(flagSchedule),
-		DebugMode:         v.GetBool(flagDebugMode),
+		DebugMode:         GetDebugMode(),
 	}
 
 	return params, nil
@@ -166,6 +175,12 @@ func AddRunFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().String(flagCandidateID, "", "Candidate id")
 	cmd.MarkPersistentFlagRequired(flagCandidateID)
+
+	viper.BindPFlags(cmd.PersistentFlags())
+}
+
+func AddInfoFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringP(flagOutputFormat, "o", "yaml", "Output format\nOne of \"yaml\", \"json\"")
 
 	viper.BindPFlags(cmd.PersistentFlags())
 }

--- a/pkg/election/election_client.go
+++ b/pkg/election/election_client.go
@@ -1,0 +1,208 @@
+// Copyright 2022 Scality, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	logrus "github.com/sirupsen/logrus"
+)
+
+type ZooKeeperElectionClient struct {
+	zk       zkClient
+	basePath string
+	debug    bool
+	log      *logrus.Entry
+}
+
+func NewZooKeeperElectionClient(servers []string, electionPath string, sessionTimeout time.Duration, debug bool, l *logrus.Entry) (*ZooKeeperElectionClient, error) {
+	zlog := l.WithField("name", "election-client-zk-client")
+
+	zk, err := connectZkClient(servers, sessionTimeout, debug, zlog)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &ZooKeeperElectionClient{
+		zk:       zk,
+		basePath: electionPath,
+		debug:    debug,
+		log:      l,
+	}
+
+	return ret, nil
+}
+
+func (ec ZooKeeperElectionClient) parseTime(s string) time.Time {
+	t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", strings.Split(s, " m=")[0])
+	if err != nil {
+		ec.log.Warn(err)
+
+		return time.Time{}
+	}
+
+	return t
+}
+
+func (ec ZooKeeperElectionClient) getDurationSince(s string) time.Duration {
+	return time.Now().Sub(ec.parseTime(s))
+}
+
+func (ec ZooKeeperElectionClient) Inspect() (*ZooKeeperElectionStatus, error) {
+	hasLeaderInfo := true
+
+	data, _, err := ec.zk.Get(ec.basePath)
+	if err != nil {
+		ec.log.Warnf("get election node: %v", err)
+
+		hasLeaderInfo = false
+	}
+
+	leaderInfo := LeaderInfo{}
+
+	if hasLeaderInfo {
+		err = json.Unmarshal(data, &leaderInfo)
+		if err != nil {
+			ec.log.Warnf("parse leader node data: %v", err)
+
+			hasLeaderInfo = false
+		}
+	}
+
+	proposalNodes, err := ec.zk.ListChildren(ec.basePath)
+	if err != nil {
+		return nil, fmt.Errorf("list candidates: %w", err)
+	}
+
+	foundLeaderInProposalNodes := false
+
+	for _, n := range proposalNodes {
+		if ec.basePath+"/"+n == leaderInfo.ProposalNode {
+			foundLeaderInProposalNodes = true
+
+			break
+		}
+	}
+
+	leaderIsOld := false
+
+	if hasLeaderInfo {
+		leaderInfo.Notes = []string{"is leader"}
+
+		sessionTimeout, _ := time.ParseDuration(leaderInfo.SessionTimeout)
+
+		lastSeenDuration := ec.getDurationSince(leaderInfo.LastSeenTime)
+		leaderInfo.Notes = append(leaderInfo.Notes, fmt.Sprintf("last heartbeat %v ago", lastSeenDuration))
+
+		if lastSeenDuration > sessionTimeout/2 {
+			leaderIsOld = true
+		}
+
+		if leaderIsOld {
+			leaderInfo.Notes = append(leaderInfo.Notes, "last heartbeat is older than the expected publish interval")
+		}
+
+		if !foundLeaderInProposalNodes {
+			leaderInfo.Notes = append(leaderInfo.Notes, "possibly resigning")
+			leaderInfo.Notes = append(leaderInfo.Notes, "election may be in progress")
+		}
+	}
+
+	sort.Strings(proposalNodes)
+
+	candidates := make([]CandidateInfo, 0, len(proposalNodes))
+
+	for _, node := range proposalNodes {
+		var candidateInfo CandidateInfo
+		var notes []string
+
+		nodePath := ec.basePath + "/" + node
+		isLeader := nodePath == leaderInfo.ProposalNode
+		isLowestNode := len(proposalNodes) > 0 && node == proposalNodes[0]
+
+		if isLowestNode {
+			if isLeader {
+				notes = append(notes, "this proposal node claimed leadership")
+			} else {
+				notes = append(notes, "should be leader but another candidate is claiming the role")
+				notes = append(notes, "possibly waiting for previous leader resignation")
+			}
+		}
+
+		data, stat, err := ec.zk.Get(nodePath)
+		if err != nil {
+			ec.log.Warnf("get candidate %s: %v", node, err)
+
+			notes = append(notes, "gone")
+
+			candidates = append(candidates, CandidateInfo{
+				CandidateID:  node,
+				Notes:        notes,
+				ProposalNode: nodePath,
+			})
+
+			continue
+		}
+
+		err = json.Unmarshal(data, &candidateInfo)
+		if err != nil {
+			ec.log.Warnf("unmarshal candidate %s: %v", node, err)
+
+			notes = append(notes, "unparseable")
+
+			candidates = append(candidates, CandidateInfo{
+				CandidateID:  node,
+				Notes:        notes,
+				ProposalNode: nodePath,
+			})
+
+			continue
+		}
+
+		if candidateInfo.CandidateID == leaderInfo.CandidateID {
+			notes = append(notes, "this candidate id claimed leadership")
+
+			if leaderIsOld {
+				notes = append(notes, "possibly resigning")
+			}
+		}
+
+		if candidateInfo.ProposalNode == "" {
+			candidateInfo.ProposalNode = nodePath
+		}
+
+		notes = append(notes, fmt.Sprintf("proposal node created %v ago", ec.getDurationSince(candidateInfo.ProposalTime)))
+
+		drift := convertMsEpochToTime(stat.Mtime).Sub(ec.parseTime(candidateInfo.ProposalTime))
+		if drift > time.Millisecond || drift < -time.Millisecond {
+			notes = append(notes, fmt.Sprintf("time drift of %v between proposal and zookeeper write", drift))
+		}
+
+		candidateInfo.Notes = notes
+
+		candidates = append(candidates, candidateInfo)
+	}
+
+	ret := &ZooKeeperElectionStatus{
+		Leader:     leaderInfo,
+		Candidates: candidates,
+	}
+
+	return ret, nil
+}

--- a/pkg/election/types.go
+++ b/pkg/election/types.go
@@ -14,12 +14,19 @@
 
 package election
 
-import "context"
+import (
+	"context"
+)
 
 type Election interface {
 	BecomeLeader(ctx context.Context) error
 	Resign(ctx context.Context) error
 	Reinit() error
+}
+
+type ZooKeeperElectionStatus struct {
+	Leader     LeaderInfo      `json:"leader" yaml:"leader,omitempty"`
+	Candidates []CandidateInfo `json:"candidates" yaml:"allCandidates,omitempty"`
 }
 
 type CandidateInfo struct {

--- a/pkg/election/types.go
+++ b/pkg/election/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Scality, Inc
+// Copyright 2021-2022 Scality, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,4 +20,20 @@ type Election interface {
 	BecomeLeader(ctx context.Context) error
 	Resign(ctx context.Context) error
 	Reinit() error
+}
+
+type CandidateInfo struct {
+	CandidateID    string `json:"candidateId,omitempty" yaml:"id,omitempty"`
+	Hostname       string `json:"hostname,omitempty" yaml:"host,omitempty"`
+	PID            string `json:"pid,omitempty" yaml:"pid,omitempty"`
+	ProposalTime   string `json:"proposalTime,omitempty" yaml:"proposalTime,omitempty"`
+	ProposalNode   string `json:"proposalNode,omitempty" yaml:"proposalNode,omitempty"`
+	SessionTimeout string `json:"sessionTimeout,omitempty" yaml:"sessionTimeout,omitempty"`
+
+	Notes []string `json:"notes,omitempty" yaml:"notes,omitempty"`
+}
+
+type LeaderInfo struct {
+	CandidateInfo `json:",inline" yaml:",inline"`
+	LastSeenTime  string `json:"lastSeenTime,omitempty" yaml:"lastSeenTime,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,4 +125,5 @@ gopkg.in/ini.v1
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
Implements the `info` command that gives the status of an election, based on current observation of the zookeeper ephemeral proposal nodes and the znode tree. Mostly heuristic based, as it's not really possible to know eg if a znode has just disappeared because the job finished or because the host suddenly went offline, until later.

Tested to be backwards compatible up to v1.0.1, although output will be more accurate with ballot candidates running a recent build.

See the README.md diff for sample output.

Closes #2